### PR TITLE
Implement Differential Attention

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,12 @@
 
 The Praxis swarm is a decentralized, peer-to-peer, always online, and continuously-learning AI intelligence - with [Hivemind](https://github.com/learning-at-home/hivemind) directly-integrated into core layers of the model itself. The goal is to build an expert model that is small and simple, easy to parallelize and performant at a scale of hundreds/thousands of peers. We will do this via a sparse mixture of experts, curated routing, algorithmic switching and weighted self-modeling of remotely-hosted peers.
 
-## design
+## architecture
 
 - A [Mixture of Depths](https://arxiv.org/abs/2404.02258) allows us to route just a subset of all tokens in a sequence to remote peers - reducing the time required for remote computation, and the amount of data transferred.
 - [LayerShuffle](https://arxiv.org/abs/2407.04513) proved that transformers can maintain coherence, even when every layer is shuffled at every forward pass. ~~We take this a step further, and implement a controller that predicts an optimized layer order.~~ The ability to work with out-of-order layers is crucial in a decentralized architecture, where some peers may fail, others may disappear, some may be overloaded, or undertrained, or are otherwise penalized for some reason or another...
+- [Attention with Linear Biases (ALiBi)](https://arxiv.org/abs/2108.12409) for length extrapolation, because it's easy and it requires no trainable parameters.
+- [Differential Attention](https://arxiv.org/abs/2410.05258) is used to improve hallucination performance, reduce parameter counts required for attention, and filter-out noise in attention maps.
 
 ## join us
 

--- a/README.md
+++ b/README.md
@@ -123,22 +123,22 @@ print(self.tokenizer.decode(outputs[0], skip_special_tokens=True))
 - [self-modeling](https://arxiv.org/abs/2407.10188) makes peers easier to model (amongst themselves)
 - layers as experts
 - commit to yourself
-- cascade-style token routing (peer1 -> peer2 -> peer3 -> return) via a Mixture of Depths
+- cascade-style token routing (ping -> pang -> pong -> ping) via a Mixture of Depths
 - treat every peer as an experiment in hyperparameter search; publish results to the DHT, and ensure that better-performing hparams are assigned more often
 - build connectors, allowing people to integrate their nodes with personal data
 
 ## tbd
 
 - a proper and robust DHT
-- central and persistent relay peers, to act as global initial_peers
-- a routing algorithm with multi-hop support (ping -> pang -> pong -> ping)
+- central and persistent relay peers, to act as global bootstrap nodes
 - helix, octopi, pyramids
-- multi-level experts
+- multi-block, heirarchical experts
 - peer validation (zero knowledge proofs)
 - self-modeling of remote experts
-- [Soft Merging of Experts with Adaptive Routing](https://arxiv.org/abs/2306.03745)?
-- [Mixture of a Million Experts](https://arxiv.org/abs/2407.04153)?
+- [Soft Merging of Experts with Adaptive Routing](https://arxiv.org/abs/2306.03745)
+- [Mixture of a Million Experts](https://arxiv.org/abs/2407.04153)
 - [T-FREE Tokenizer](https://github.com/aleph-alpha/trigrams)
+- [Mini-Sequence Transformer](https://github.com/wdlctc/mini-s/tree/main) (probably not worth it on the smaller scale)
 
 ## won't do
 

--- a/misc/bad_expert.py
+++ b/misc/bad_expert.py
@@ -1,0 +1,73 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from transformers.activations import ACT2FN
+
+from praxis import PraxisConfig
+
+
+class ExpertGLU(nn.Module):
+    def __init__(self, config: PraxisConfig):
+        super().__init__()
+        self.up = nn.Linear(config.n_dim, 8 * config.n_dim)
+        self.act = ACT2FN[config.activation]
+        self.down = nn.Linear(4 * config.n_dim, config.n_dim)
+
+    def forward(self, x):
+        a, b = self.up(x).chunk(2, dim=-1)
+        return self.down(a * self.act(b))
+
+
+class SparseMoEMLP(nn.Module):
+    def __init__(self, config: PraxisConfig, num_experts: int = 8, top_k: int = 2):
+        super().__init__()
+        self.num_experts = num_experts
+        self.top_k = top_k
+
+        # Create multiple experts
+        self.experts = nn.ModuleList([ExpertGLU(config) for _ in range(num_experts)])
+
+        # Router network
+        self.router = nn.Linear(config.n_dim, num_experts)
+
+    def forward(self, x):
+        # Get batch size and sequence length
+        batch_size, seq_len, _ = x.shape
+
+        # Flatten the input
+        flat_x = x.view(-1, x.size(-1))  # (batch_size * seq_len, n_dim)
+
+        # Route the input
+        router_logits = self.router(flat_x)  # (batch_size * seq_len, num_experts)
+
+        # Select top-k experts
+        top_k_logits, top_k_indices = torch.topk(router_logits, self.top_k, dim=-1)
+        top_k_probs = F.softmax(top_k_logits, dim=-1)
+
+        # Compute expert outputs
+        expert_outputs = torch.zeros_like(flat_x)
+        for k in range(self.top_k):
+            expert_index = top_k_indices[:, k]
+            prob = top_k_probs[:, k].unsqueeze(-1)
+            for i, expert in enumerate(self.experts):
+                # Create a mask for this expert
+                mask = expert_index == i
+                if mask.any():
+                    # Only compute for samples that use this expert
+                    expert_inputs = flat_x[mask]
+                    expert_output = expert(expert_inputs)
+                    # Combine expert outputs weighted by router probabilities
+                    expert_outputs[mask] += expert_output * prob[mask]
+
+        # Reshape output back to original shape
+        output = expert_outputs.view(batch_size, seq_len, -1)
+
+        return output
+
+
+# Usage
+config = PraxisConfig(n_dim=512, activation="gelu")
+moe_mlp = SparseMoEMLP(config, num_experts=8, top_k=2)
+input_tensor = torch.randn(32, 64, 512)  # (batch_size, seq_len, n_dim)
+output = moe_mlp(input_tensor)
+print(output)

--- a/misc/mid_expert.py
+++ b/misc/mid_expert.py
@@ -1,0 +1,63 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from transformers.activations import ACT2FN
+
+from praxis import PraxisConfig
+
+
+class SparseMoEMLP(nn.Module):
+    def __init__(self, config: PraxisConfig, num_experts: int = 8, top_k: int = 2):
+        super().__init__()
+        self.num_experts = num_experts
+        self.top_k = top_k
+        self.n_dim = config.n_dim
+
+        # Single set of expert weights
+        self.w1 = nn.Parameter(torch.randn(num_experts, config.n_dim, 4 * config.n_dim))
+        self.w2 = nn.Parameter(torch.randn(num_experts, 4 * config.n_dim, config.n_dim))
+        self.b1 = nn.Parameter(torch.zeros(num_experts, 4 * config.n_dim))
+        self.b2 = nn.Parameter(torch.zeros(num_experts, config.n_dim))
+
+        # Router network
+        self.router = nn.Linear(config.n_dim, num_experts)
+
+        self.act = ACT2FN[config.activation]
+
+    def forward(self, x):
+        batch_size, seq_len, _ = x.shape
+
+        # Route the input
+        router_logits = self.router(x)  # (batch_size, seq_len, num_experts)
+
+        # Select top-k experts
+        top_k_logits, top_k_indices = torch.topk(router_logits, self.top_k, dim=-1)
+        top_k_probs = F.softmax(top_k_logits, dim=-1)
+
+        # Create masks for selected experts
+        masks = F.one_hot(top_k_indices, num_classes=self.num_experts).float()
+
+        # Expert computation (in parallel)
+        x_e = x.unsqueeze(2).expand(
+            -1, -1, self.num_experts, -1
+        )  # (batch_size, seq_len, num_experts, n_dim)
+        h = torch.einsum("bsed,edh->bseh", x_e, self.w1) + self.b1.unsqueeze(
+            0
+        ).unsqueeze(0)
+        h = self.act(h)
+        y = torch.einsum("bseh,ehd->bsed", h, self.w2) + self.b2.unsqueeze(0).unsqueeze(
+            0
+        )
+
+        # Combine expert outputs
+        combined_output = torch.einsum("bsed,bske,bsk->bsd", y, masks, top_k_probs)
+
+        return combined_output
+
+
+# Usage
+config = PraxisConfig(n_dim=512, activation="gelu")
+moe_mlp = SparseMoEMLP(config, num_experts=8, top_k=2)
+input_tensor = torch.randn(32, 64, 512)  # (batch_size, seq_len, n_dim)
+output = moe_mlp(input_tensor)
+print(output)

--- a/praxis/configuration_praxis.py
+++ b/praxis/configuration_praxis.py
@@ -10,6 +10,7 @@ class PraxisConfig(PretrainedConfig):
         n_dim=384,
         n_layer=12,
         n_head=8,
+        differential_heads=1,
         dropout=0,
         epsilon=1e-5,
         capacity=0.125,
@@ -37,6 +38,7 @@ class PraxisConfig(PretrainedConfig):
         self.n_dim = n_dim
         self.n_layer = n_layer
         self.n_head = n_head
+        self.differential_heads = differential_heads
         self.dropout = dropout
         self.epsilon = epsilon
         self.capacity = capacity

--- a/praxis/modules/attention.py
+++ b/praxis/modules/attention.py
@@ -9,6 +9,14 @@ from ..configuration_praxis import PraxisConfig
 
 
 class PraxisAttention(nn.Module):
+    """
+    We implement Differential Attention, to filter the noise from attention maps:
+    https://arxiv.org/abs/2410.05258
+
+    We also implement ALiBi, to keep parameter counts low:
+    https://arxiv.org/abs/2108.12409
+    """
+
     def __init__(self, config: PraxisConfig):
         super().__init__()
         self.causal = config.causal
@@ -16,11 +24,14 @@ class PraxisAttention(nn.Module):
         self.hidden_size = config.n_dim
         self.num_heads = config.n_head
         self.head_dim = self.hidden_size // self.num_heads
-        self.query = nn.Linear(
-            self.hidden_size, self.num_heads * self.head_dim, bias=False
+        self.differential_heads = config.differential_heads
+        self.query = nn.ModuleList(
+            nn.Linear(self.hidden_size, self.num_heads * self.head_dim, bias=False)
+            for _ in range(self.differential_heads)
         )
-        self.key = nn.Linear(
-            self.hidden_size, self.num_heads * self.head_dim, bias=False
+        self.key = nn.ModuleList(
+            nn.Linear(self.hidden_size, self.num_heads * self.head_dim, bias=False)
+            for _ in range(self.differential_heads)
         )
         self.value = nn.Linear(
             self.hidden_size, self.num_heads * self.head_dim, bias=False
@@ -36,51 +47,61 @@ class PraxisAttention(nn.Module):
             "positions", torch.arange(self.max_seq_len, dtype=torch.float32)
         )
 
-    def forward(self, inputs, attention_mask=None, token_indices=None):
+        self.lambda_init = 0.8
+        self.lambdas = [
+            nn.Parameter(torch.randn(self.head_dim))
+            for _ in range(self.differential_heads * 2)
+        ]
 
+        self.norm = nn.ModuleList(
+            nn.LayerNorm(self.head_dim) for _ in range(self.num_heads)
+        )
+
+    def forward(self, inputs, attention_mask=None, token_indices=None):
         batch_size, seq_len, _ = inputs.size()
 
-        q = (
-            self.query(inputs)
-            .view(batch_size, seq_len, self.num_heads, self.head_dim)
-            .transpose(1, 2)
-        )
-        k = (
-            self.key(inputs)
-            .view(batch_size, seq_len, self.num_heads, self.head_dim)
-            .transpose(1, 2)
-        )
+        q = [
+            (
+                self.query[i](inputs)
+                .view(batch_size, seq_len, self.num_heads, self.head_dim)
+                .transpose(1, 2)
+            )
+            for i in range(self.differential_heads)
+        ]
+        k = [
+            (
+                self.key[i](inputs)
+                .view(batch_size, seq_len, self.num_heads, self.head_dim)
+                .transpose(1, 2)
+            )
+            for i in range(self.differential_heads)
+        ]
         v = (
             self.value(inputs)
             .view(batch_size, seq_len, self.num_heads, self.head_dim)
             .transpose(1, 2)
         )
 
-        scores = torch.matmul(q, k.transpose(-2, -1)) * torch.rsqrt(
-            torch.tensor(self.head_dim, device=inputs.device)
-        )
+        scores = [
+            torch.matmul(q[i], k[i].transpose(-2, -1))
+            * torch.rsqrt(torch.tensor(self.head_dim, device=inputs.device))
+            for i in range(self.differential_heads)
+        ]
 
         # Compute ALiBi biases
         if token_indices is not None:
-            positions = self.positions[token_indices]  # [batch_size, seq_len]
+            positions = self.positions[token_indices]
         else:
             positions = (
                 self.positions[:seq_len].unsqueeze(0).expand(batch_size, seq_len)
-            )  # [batch_size, seq_len]
+            )
 
-        # Compute position differences
-        pos_diff = positions.unsqueeze(2) - positions.unsqueeze(
-            1
-        )  # [batch_size, seq_len, seq_len]
+        pos_diff = positions.unsqueeze(2) - positions.unsqueeze(1)
 
-        # Compute biases
-        slopes = self.slopes.view(1, self.num_heads, 1, 1)  # [1, num_heads, 1, 1]
-        biases = slopes * pos_diff.unsqueeze(
-            1
-        )  # [batch_size, num_heads, seq_len, seq_len]
+        slopes = self.slopes.view(1, self.num_heads, 1, 1)
+        biases = slopes * pos_diff.unsqueeze(1)
 
-        # Subtract biases from the scores
-        scores -= biases
+        scores = [scores[i] - biases for i in range(self.differential_heads)]
 
         # Apply the causal mask
         if self.causal:
@@ -92,16 +113,150 @@ class PraxisAttention(nn.Module):
                 .unsqueeze(0)
                 .unsqueeze(0)
             )
-            scores += causal_mask
+            scores = [scores[i] + causal_mask for i in range(self.differential_heads)]
 
         if attention_mask is not None:
-            scores *= attention_mask.unsqueeze(1).unsqueeze(1)
+            mask = attention_mask.unsqueeze(1).unsqueeze(1)
+            scores = [scores[i] * mask for i in range(self.differential_heads)]
 
-        weights = F.softmax(scores, dim=-1)
-        attention = (
-            torch.matmul(weights, v)
-            .transpose(1, 2)
-            .reshape(batch_size, seq_len, self.hidden_size)
+        # Compute softmax for all differential heads
+        weights = [F.softmax(scores[i], dim=-1) for i in range(self.differential_heads)]
+
+        # Set the initial weights
+        diff_weights = weights[0]
+        if len(weights) > 1:
+            # Compute lambda
+            lamb = 0
+            for i in range(0, len(self.lambdas), 2):
+                lamb = (
+                    lamb
+                    - torch.exp(torch.dot(self.lambdas[i], self.lambdas[i + 1]))
+                    + self.lambda_init
+                )
+            # Compute the differential attention weights
+            for i, w in enumerate(weights):
+                if i + 1 >= len(weights):
+                    break
+                diff_weights = diff_weights - lamb * weights[i + 1]
+
+        # Apply LayerNorm to each head
+        attention_heads = torch.matmul(diff_weights, v).transpose(1, 2)
+        attention_heads = torch.stack(
+            [self.norm[i](attention_heads[..., i, :]) for i in range(self.num_heads)],
+            dim=-2,
+        )
+
+        attention = attention_heads.reshape(
+            batch_size, seq_len, self.num_heads * self.head_dim
         )
 
         return self.output(attention)
+
+
+# import math
+# from typing import Optional, Tuple, Union
+
+# import torch
+# import torch.nn as nn
+# import torch.nn.functional as F
+
+# from ..configuration_praxis import PraxisConfig
+
+
+# class PraxisAttention(nn.Module):
+#     def __init__(self, config: PraxisConfig):
+#         super().__init__()
+#         self.causal = config.causal
+#         self.max_seq_len = config.context_length
+#         self.hidden_size = config.n_dim
+#         self.num_heads = config.n_head
+#         self.head_dim = self.hidden_size // self.num_heads
+#         self.query = nn.Linear(
+#             self.hidden_size, self.num_heads * self.head_dim, bias=False
+#         )
+#         self.key = nn.Linear(
+#             self.hidden_size, self.num_heads * self.head_dim, bias=False
+#         )
+#         self.value = nn.Linear(
+#             self.hidden_size, self.num_heads * self.head_dim, bias=False
+#         )
+#         self.output = nn.Linear(
+#             self.num_heads * self.head_dim, self.hidden_size, bias=False
+#         )
+
+#         # Pre-compute the ALiBi slopes
+#         slopes = 2 ** (-8 * torch.arange(1, self.num_heads + 1) / self.num_heads)
+#         self.register_buffer("slopes", slopes)
+#         self.register_buffer(
+#             "positions", torch.arange(self.max_seq_len, dtype=torch.float32)
+#         )
+
+#     def forward(self, inputs, attention_mask=None, token_indices=None):
+
+#         batch_size, seq_len, _ = inputs.size()
+
+#         q = (
+#             self.query(inputs)
+#             .view(batch_size, seq_len, self.num_heads, self.head_dim)
+#             .transpose(1, 2)
+#         )
+#         k = (
+#             self.key(inputs)
+#             .view(batch_size, seq_len, self.num_heads, self.head_dim)
+#             .transpose(1, 2)
+#         )
+#         v = (
+#             self.value(inputs)
+#             .view(batch_size, seq_len, self.num_heads, self.head_dim)
+#             .transpose(1, 2)
+#         )
+
+#         scores = torch.matmul(q, k.transpose(-2, -1)) * torch.rsqrt(
+#             torch.tensor(self.head_dim, device=inputs.device)
+#         )
+
+#         # Compute ALiBi biases
+#         if token_indices is not None:
+#             positions = self.positions[token_indices]  # [batch_size, seq_len]
+#         else:
+#             positions = (
+#                 self.positions[:seq_len].unsqueeze(0).expand(batch_size, seq_len)
+#             )  # [batch_size, seq_len]
+
+#         # Compute position differences
+#         pos_diff = positions.unsqueeze(2) - positions.unsqueeze(
+#             1
+#         )  # [batch_size, seq_len, seq_len]
+
+#         # Compute biases
+#         slopes = self.slopes.view(1, self.num_heads, 1, 1)  # [1, num_heads, 1, 1]
+#         biases = slopes * pos_diff.unsqueeze(
+#             1
+#         )  # [batch_size, num_heads, seq_len, seq_len]
+
+#         # Subtract biases from the scores
+#         scores -= biases
+
+#         # Apply the causal mask
+#         if self.causal:
+#             causal_mask = (
+#                 torch.triu(
+#                     torch.ones(seq_len, seq_len, device=inputs.device) * float("-inf"),
+#                     diagonal=1,
+#                 )
+#                 .unsqueeze(0)
+#                 .unsqueeze(0)
+#             )
+#             scores += causal_mask
+
+#         if attention_mask is not None:
+#             scores *= attention_mask.unsqueeze(1).unsqueeze(1)
+
+#         weights = F.softmax(scores, dim=-1)
+#         attention = (
+#             torch.matmul(weights, v)
+#             .transpose(1, 2)
+#             .reshape(batch_size, seq_len, self.hidden_size)
+#         )
+
+#         return self.output(attention)

--- a/praxis/modules/attention.py
+++ b/praxis/modules/attention.py
@@ -54,10 +54,10 @@ class PraxisAttention(nn.Module):
                     ),
                 )
             )
+            self.norm = nn.GroupNorm(
+                num_groups=self.num_heads, num_channels=self.num_heads * self.head_dim
+            )
 
-        self.norm = nn.GroupNorm(
-            num_groups=self.num_heads, num_channels=self.num_heads * self.head_dim
-        )
         self.output = nn.Linear(
             self.num_heads * self.head_dim, self.hidden_size, bias=False
         )
@@ -123,8 +123,10 @@ class PraxisAttention(nn.Module):
             scores = [scores[i] + causal_mask for i in range(self.differential_heads)]
 
         if attention_mask is not None:
-            mask = (1.0 - attention_mask.unsqueeze(1).unsqueeze(2)) * -1e9
-            scores = [scores[i] + mask for i in range(self.differential_heads)]
+            attention_mask = (1.0 - attention_mask.unsqueeze(1).unsqueeze(2)) * -1e9
+            scores = [
+                scores[i] + attention_mask for i in range(self.differential_heads)
+            ]
 
         # Compute attention weights
         weights = [F.softmax(scores[i], dim=-1) for i in range(self.differential_heads)]

--- a/praxis/modules/attention.py
+++ b/praxis/modules/attention.py
@@ -1,5 +1,5 @@
 import math
-from typing import Optional, Tuple, Union
+from typing import Optional, OrderedDict, Tuple, Union
 
 import torch
 import torch.nn as nn
@@ -13,11 +13,11 @@ class PraxisAttention(nn.Module):
     We implement Differential Attention, to filter the noise from attention maps:
     https://arxiv.org/abs/2410.05258
 
-    We also implement ALiBi, to keep parameter counts low:
+    We implement ALiBi for length extrapolation, to keep parameter counts low:
     https://arxiv.org/abs/2108.12409
     """
 
-    def __init__(self, config: PraxisConfig):
+    def __init__(self, config):
         super().__init__()
         self.causal = config.causal
         self.max_seq_len = config.context_length
@@ -25,6 +25,8 @@ class PraxisAttention(nn.Module):
         self.num_heads = config.n_head
         self.head_dim = self.hidden_size // self.num_heads
         self.differential_heads = config.differential_heads
+
+        # Query and key projections for differential heads
         self.query = nn.ModuleList(
             nn.Linear(self.hidden_size, self.num_heads * self.head_dim, bias=False)
             for _ in range(self.differential_heads)
@@ -35,6 +37,26 @@ class PraxisAttention(nn.Module):
         )
         self.value = nn.Linear(
             self.hidden_size, self.num_heads * self.head_dim, bias=False
+        )
+
+        # Lambda vectors per differential head and per head
+        if self.differential_heads > 1:
+            self.lambda_init = 0.8  # As per the paper
+            self.lambdas = nn.ModuleDict(
+                OrderedDict(
+                    q=nn.ParameterList(
+                        nn.Parameter(torch.randn(self.num_heads, self.head_dim))
+                        for _ in range(self.differential_heads)
+                    ),
+                    k=nn.ParameterList(
+                        nn.Parameter(torch.randn(self.num_heads, self.head_dim))
+                        for _ in range(self.differential_heads)
+                    ),
+                )
+            )
+
+        self.norm = nn.GroupNorm(
+            num_groups=self.num_heads, num_channels=self.num_heads * self.head_dim
         )
         self.output = nn.Linear(
             self.num_heads * self.head_dim, self.hidden_size, bias=False
@@ -47,33 +69,20 @@ class PraxisAttention(nn.Module):
             "positions", torch.arange(self.max_seq_len, dtype=torch.float32)
         )
 
-        self.lambda_init = 0.8
-        self.lambdas = [
-            nn.Parameter(torch.randn(self.head_dim))
-            for _ in range(self.differential_heads * 2)
-        ]
-
-        self.norm = nn.ModuleList(
-            nn.LayerNorm(self.head_dim) for _ in range(self.num_heads)
-        )
-
     def forward(self, inputs, attention_mask=None, token_indices=None):
         batch_size, seq_len, _ = inputs.size()
 
+        # Compute queries, keys, and values
         q = [
-            (
-                self.query[i](inputs)
-                .view(batch_size, seq_len, self.num_heads, self.head_dim)
-                .transpose(1, 2)
-            )
+            self.query[i](inputs)
+            .view(batch_size, seq_len, self.num_heads, self.head_dim)
+            .transpose(1, 2)  # Shape: (batch_size, num_heads, seq_len, head_dim)
             for i in range(self.differential_heads)
         ]
         k = [
-            (
-                self.key[i](inputs)
-                .view(batch_size, seq_len, self.num_heads, self.head_dim)
-                .transpose(1, 2)
-            )
+            self.key[i](inputs)
+            .view(batch_size, seq_len, self.num_heads, self.head_dim)
+            .transpose(1, 2)
             for i in range(self.differential_heads)
         ]
         v = (
@@ -82,9 +91,10 @@ class PraxisAttention(nn.Module):
             .transpose(1, 2)
         )
 
+        # Compute attention scores
+        scale = 1.0 / math.sqrt(self.head_dim)
         scores = [
-            torch.matmul(q[i], k[i].transpose(-2, -1))
-            * torch.rsqrt(torch.tensor(self.head_dim, device=inputs.device))
+            torch.matmul(q[i], k[i].transpose(-2, -1)) * scale
             for i in range(self.differential_heads)
         ]
 
@@ -97,17 +107,14 @@ class PraxisAttention(nn.Module):
             )
 
         pos_diff = positions.unsqueeze(2) - positions.unsqueeze(1)
-
-        slopes = self.slopes.view(1, self.num_heads, 1, 1)
-        biases = slopes * pos_diff.unsqueeze(1)
-
+        biases = self.slopes.view(1, self.num_heads, 1, 1) * pos_diff.unsqueeze(1)
         scores = [scores[i] - biases for i in range(self.differential_heads)]
 
-        # Apply the causal mask
+        # Apply masks
         if self.causal:
             causal_mask = (
                 torch.triu(
-                    torch.ones(seq_len, seq_len, device=inputs.device) * float("-inf"),
+                    torch.full((seq_len, seq_len), -1e9, device=inputs.device),
                     diagonal=1,
                 )
                 .unsqueeze(0)
@@ -116,41 +123,79 @@ class PraxisAttention(nn.Module):
             scores = [scores[i] + causal_mask for i in range(self.differential_heads)]
 
         if attention_mask is not None:
-            mask = attention_mask.unsqueeze(1).unsqueeze(1)
-            scores = [scores[i] * mask for i in range(self.differential_heads)]
+            mask = (1.0 - attention_mask.unsqueeze(1).unsqueeze(2)) * -1e9
+            scores = [scores[i] + mask for i in range(self.differential_heads)]
 
-        # Compute softmax for all differential heads
+        # Compute attention weights
         weights = [F.softmax(scores[i], dim=-1) for i in range(self.differential_heads)]
 
-        # Set the initial weights
-        diff_weights = weights[0]
-        if len(weights) > 1:
-            # Compute lambda
-            lamb = 0
-            for i in range(0, len(self.lambdas), 2):
-                lamb = (
-                    lamb
-                    - torch.exp(torch.dot(self.lambdas[i], self.lambdas[i + 1]))
-                    + self.lambda_init
-                )
-            # Compute the differential attention weights
-            for i, w in enumerate(weights):
-                if i + 1 >= len(weights):
-                    break
-                diff_weights = diff_weights - lamb * weights[i + 1]
+        # return early if we aren't using differential attention
+        if self.differential_heads == 1:
+            # Use standard attention
+            attention = (
+                torch.matmul(weights[0], v)
+                .transpose(1, 2)
+                .reshape(batch_size, seq_len, self.hidden_size)
+            )
+            # Output projection
+            return self.output(attention)
 
-        # Apply LayerNorm to each head
-        attention_heads = torch.matmul(diff_weights, v).transpose(1, 2)
-        attention_heads = torch.stack(
-            [self.norm[i](attention_heads[..., i, :]) for i in range(self.num_heads)],
-            dim=-2,
-        )
+        # Compute scalar lambdas per head via dot products
+        lambda_scalars = []
+        for i in range(self.differential_heads):
+            # Shape: (num_heads, head_dim)
+            lambda_q_i = self.lambdas["q"][i]
+            lambda_k_i = self.lambdas["k"][i]
 
-        attention = attention_heads.reshape(
+            # Compute dot product across head_dim for each head
+            dot_product = (lambda_q_i * lambda_k_i).sum(dim=-1)  # Shape: (num_heads,)
+
+            # Compute scalar lambda per head
+            lambda_scalar = torch.exp(dot_product)  # Shape: (num_heads,)
+            lambda_scalars.append(lambda_scalar)
+
+        # Compute the overall lambda per head
+        lamb = self.lambda_init * torch.ones(
+            self.num_heads, device=inputs.device
+        )  # Shape: (num_heads,)
+        for i, lambda_scalar in enumerate(lambda_scalars):
+            sign = (-1) ** i
+            lamb += sign * lambda_scalar  # Shape: (num_heads,)
+
+        # Expand lamb to (1, num_heads, 1, 1) for broadcasting
+        lamb_expanded = (
+            lamb.unsqueeze(0).unsqueeze(-1).unsqueeze(-1)
+        )  # (1, num_heads, 1, 1)
+
+        # Compute differential attention weights
+        diff_weights = lamb_expanded * weights[0]
+        for i in range(1, self.differential_heads):
+            sign = (-1) ** i
+            diff_weights += sign * lamb_expanded * weights[i]
+
+        # Compute attention output
+        attention_scores = torch.matmul(diff_weights, v)
+        # Shape: (batch_size, num_heads, seq_len, head_dim)
+
+        # Reshape and apply GroupNorm
+        attention_scores = attention_scores.permute(0, 2, 1, 3).contiguous()
+        # Shape: (batch_size, seq_len, num_heads, head_dim)
+
+        attention_scores = attention_scores.view(
             batch_size, seq_len, self.num_heads * self.head_dim
         )
+        # Shape: (batch_size, seq_len, num_heads * head_dim)
 
-        return self.output(attention)
+        attention_scores = attention_scores.transpose(1, 2)
+        # Shape: (batch_size, num_heads * head_dim, seq_len)
+
+        attention_scores = self.norm(attention_scores)
+
+        attention_scores = attention_scores.transpose(1, 2)
+        # Shape: (batch_size, seq_len, num_heads * head_dim)
+
+        # Output projection
+        return self.output(attention_scores)
 
 
 # import math

--- a/praxis/modules/embeddings.py
+++ b/praxis/modules/embeddings.py
@@ -6,6 +6,11 @@ from ..configuration_praxis import PraxisConfig
 
 
 class PraxisEmbedding(nn.Sequential):
+    """
+    A simple token embeddings layer with a linear projection into
+    a reduced dimension.
+    """
+
     def __init__(self, config: PraxisConfig):
         super().__init__(
             OrderedDict(

--- a/praxis/modules/experts.py
+++ b/praxis/modules/experts.py
@@ -31,7 +31,8 @@ class PraxisBlock(nn.Module):
     ):
         residual = inputs
         normalized = self.attn_norm(inputs)
-        outputs = self.attn(normalized, attention_mask, token_indices) + residual
+        outputs = self.attn(normalized, attention_mask, token_indices)
+        outputs = outputs + residual
         residual = outputs
         normalized = self.mlp_norm(outputs)
         outputs = self.mlp(normalized)
@@ -39,7 +40,8 @@ class PraxisBlock(nn.Module):
         if router_weights is not None:
             outputs *= router_weights
         aux_loss = 0
-        return outputs + residual, aux_loss
+        outputs = outputs + residual
+        return outputs, aux_loss
 
 
 @register_expert_class("praxis_mlp", input_shape)

--- a/praxis/modules/router.py
+++ b/praxis/modules/router.py
@@ -50,7 +50,7 @@ class PraxisMixtureOfDepths(nn.Linear):
             )
         else:
             # top-k can see into the future, breaking causality; a sigmoid operation
-            # allows us to sample autoregressively, during inference
+            # allows us to sample autoregressively during inference
             token_mask = torch.sigmoid(router_logits) > 0.5
             token_indices = torch.nonzero(token_mask, as_tuple=True)[1].view(b, -1)
 

--- a/run.py
+++ b/run.py
@@ -240,6 +240,7 @@ config = PraxisConfig(
     n_dim=384,
     n_layer=args.depth if not dev else 3,
     n_head=8,
+    differential_heads=2,
     dropout=0.1,
     vocab_size=tokenizer.vocab_size,
     context_length=4096,

--- a/run.py
+++ b/run.py
@@ -21,6 +21,7 @@ signal.signal(signal.SIGINT, sigint_handler)
 
 
 import argparse
+import contextlib
 import itertools
 import logging
 import math
@@ -327,12 +328,11 @@ predict_tokens = 1
 # from: https://pytorch-optimizers.readthedocs.io/en/latest/optimizer
 min_lr = 1e-5
 hparams["optimizer"] = dict(
-    optimizer_name="AdamW",
+    optimizer_name="AdEMAMix",
     lr=1e-3,
     weight_decay=1e-2,
-    # num_embeds=config.n_emb,
-    # num_heads=config.n_head,
-    # num_query_groups=config.n_head,
+    weight_decouple=True,
+    alpha=5.9,
     wd_ban_list=[
         "bias",
         "wte",
@@ -343,11 +343,11 @@ hparams["optimizer"] = dict(
 
 scheduler_func = partial(
     CosineAnnealingWarmupRestarts,
-    first_cycle_steps=4096,
+    first_cycle_steps=4096 * 4,
     max_lr=hparams["optimizer"]["lr"],
     min_lr=min_lr,
     gamma=1.0,
-    warmup_steps=256,
+    warmup_steps=512,
 )
 
 
@@ -387,8 +387,6 @@ class PraxisTrainer(LightningModule):
             prog_bar=True,
         )
 
-        return loss
-
     def validation_step(self, batch, batch_idx):
         outputs = self.model(input_ids=batch, labels=batch)
         loss = outputs[0]
@@ -407,8 +405,6 @@ class PraxisTrainer(LightningModule):
             batch_size=batch_size,
             prog_bar=True,
         )
-
-        return {"val_loss": loss, "val_perplexity": perplexity}
 
     def configure_optimizers(self):
         "Create optimizer and scheduler"
@@ -453,6 +449,12 @@ class TerminalInterface(Callback):
             except KeyboardInterrupt:
                 self.dashboard.stop()
 
+    def on_train_start(self, trainer, lm):
+        super().on_train_start(trainer, lm)
+        if self.dashboard:
+            total_params = sum(p.numel() for p in lm.model.parameters())
+            self.dashboard.update_params(total_params)
+
     def on_train_batch_start(self, trainer, lm, batch, batch_idx):
         super().on_train_batch_start(trainer, lm, batch, batch_idx)
         if self.dashboard:
@@ -486,11 +488,10 @@ class TerminalInterface(Callback):
         if self.dashboard:
             batch = trainer.callback_metrics.get("batch", 0)
             step = trainer.callback_metrics.get("step", 0)
-            total_params = sum(p.numel() for p in lm.model.parameters())
-            self.dashboard.update_params(total_params)
             self.dashboard.update_batch(batch.item())
             self.dashboard.update_step(step.item())
             self.dashboard.update_loss(self.ema_loss)
+            self.dashboard.fake_log(chance=0.000001)
             if random.random() < 0.25:
                 self.dashboard.update_validator(
                     self._sign_wave(
@@ -500,14 +501,11 @@ class TerminalInterface(Callback):
                         step=batch_idx,
                     )
                 )
-            self.dashboard.fake_log(chance=0.000001)
 
     def _generate_sample_text(self, lm, batch_idx=0, interval=10):
 
         if not self._is_trigger_passed(self.last_time, self.interval):
             return
-
-        lm.model.eval()
 
         self.text = generator.generate(self.text, {"max_new_tokens": self.num_tokens})
 
@@ -531,8 +529,6 @@ class TerminalInterface(Callback):
             return self._generate_sample_text(lm)
 
         self.last_time = datetime.now()
-
-        lm.model.train()
 
     def _sign_wave(self, amplitude=1, frequency=1, phase_shift=0, step=1):
         distribution = random.gauss(0.25, 0.2)
@@ -715,6 +711,15 @@ class Generator:
         self.model = model
         self.tokenizer = tokenizer
 
+    @contextlib.contextmanager
+    def _eval_mode(self):
+        training = self.model.training
+        self.model.eval()
+        try:
+            yield
+        finally:
+            self.model.train(training)
+
     def generate(self, prompt, kwargs={}):
         input_ids = self.tokenizer.encode(prompt, return_tensors="pt")
 
@@ -733,10 +738,10 @@ class Generator:
             repetition_penalty=1.35,
             renormalize_logits=True,
             remove_invalid_values=True,
-            suppress_tokens=[
-                self.tokenizer.eos_token_id,
-                self.tokenizer.pad_token_id,
-            ],  # else the model may degenerate to 100% [EOS] or [PAD] tokens
+            # suppress_tokens=[
+            #     self.tokenizer.eos_token_id,
+            #     self.tokenizer.pad_token_id,
+            # ],  # else the model may degenerate to 100% [EOS] or [PAD] tokens
         )
         combined = {**defaults, **kwargs}
         if "prompt" in combined:
@@ -746,16 +751,19 @@ class Generator:
         max_attempts = 30  # Prevent infinite loops
         attempts = 0
 
-        while attempts < max_attempts:
-            outputs = self.model.generate(input_ids, **combined)
-            decoded_new = self.tokenizer.decode(outputs[0], skip_special_tokens=True)
+        with self._eval_mode():
+            while attempts < max_attempts:
+                outputs = self.model.generate(input_ids, **combined)
+                decoded_new = self.tokenizer.decode(
+                    outputs[0], skip_special_tokens=True
+                )
 
-            if decoded_new != prompt:
-                return_text = decoded_new
-                break
-            else:
-                input_ids = outputs
-                attempts += 1
+                if decoded_new != prompt:
+                    return_text = decoded_new
+                    break
+                else:
+                    input_ids = outputs
+                    attempts += 1
 
         if attempts == max_attempts:
             print("Warning: Reached maximum attempts without generating a valid token")

--- a/run.py
+++ b/run.py
@@ -387,6 +387,8 @@ class PraxisTrainer(LightningModule):
             prog_bar=True,
         )
 
+        return loss
+
     def validation_step(self, batch, batch_idx):
         outputs = self.model(input_ids=batch, labels=batch)
         loss = outputs[0]


### PR DESCRIPTION
This PR implements [Differential Attention](https://arxiv.org/abs/2410.05258), which is a proposed method to mitigate hallucinations and filter-out noise in the self-attention mechanism. The feature is enabled by default, but can be reverted to standard self-attention by using `differential_heads=1` in the `PraxisConfiguration` object.